### PR TITLE
deleted double entry

### DIFF
--- a/orchestra-login-portal/templates/openunison/applications/anonfiles.yaml
+++ b/orchestra-login-portal/templates/openunison/applications/anonfiles.yaml
@@ -31,4 +31,3 @@ spec:
     timeout: 1
     scope: -1
     cookiesEnabled: false
-    keyAlias: session-unison


### PR DESCRIPTION
Another entry kustomize/flux complains about.
There should be no more double entries in orchestra-login-portal. At leas I checkt a template via kustomize.