### PR TITLE
fix: duplicated annotations fix

### DIFF
--- a/orchestra/Chart.yaml
+++ b/orchestra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.14
+version: 2.10.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/orchestra/templates/infrastructure/ingress-simple.yaml
+++ b/orchestra/templates/infrastructure/ingress-simple.yaml
@@ -16,6 +16,9 @@ metadata:
     app.kubernetes.io/component: ingress-simple
     app.kubernetes.io/part-of: openunison
 spec:
+  {{- if .Values.network.ingressClassName }}
+  ingressClassName: {{ .Values.network.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.network.openunison_host }}
     http:

--- a/orchestra/templates/infrastructure/jetstack.yaml
+++ b/orchestra/templates/infrastructure/jetstack.yaml
@@ -10,18 +10,10 @@ metadata:
     app.kubernetes.io/part-of: openunison
   name: kube-oidc-proxy-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{ if eq .Values.network.ingress_type "traefik" }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"
   {{ if .Values.network.traefik.secure }} 
-  annotations:
-    argocd.argoproj.io/sync-wave: "40"
     traefik.ingress.kubernetes.io/service.serversscheme: https
-  {{ else }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "40"
-  {{ end }}
-  {{ else }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "40"
   {{ end }}
 spec:
   replicas: {{ .Values.openunison.replicas }}
@@ -167,9 +159,9 @@ metadata:
     app.kubernetes.io/part-of: openunison
   name: kube-oidc-proxy-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{ if eq .Values.network.ingress_type "traefik" }}
   annotations:
     argocd.argoproj.io/sync-wave: "40"
+  {{ if eq .Values.network.ingress_type "traefik" }}
     {{ if .Values.network.traefik.secure }} 
     traefik.ingress.kubernetes.io/service.serversscheme: https
     {{ end }}

--- a/orchestra/templates/infrastructure/mgmt-proxy.yaml
+++ b/orchestra/templates/infrastructure/mgmt-proxy.yaml
@@ -135,12 +135,12 @@ metadata:
     app.kubernetes.io/part-of: openunison
   name: kube-management-proxy-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{ if eq .Values.network.ingress_type "traefik" }}
-  {{ if .Values.network.traefik.secure }} 
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+  {{ if eq .Values.network.ingress_type "traefik" }}
+    {{ if .Values.network.traefik.secure }} 
     traefik.ingress.kubernetes.io/service.serversscheme: https
-  {{ end }}
+    {{ end }}
   {{ end }}
 spec:
   replicas: {{ .Values.openunison.replicas }}
@@ -296,19 +296,17 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     app: kube-management-proxy-{{ .Release.Name }}
     app.kubernetes.io/name: openunison
     app.kubernetes.io/instance: openunison-{{ .Release.Name }}
     app.kubernetes.io/component: kube-management-proxy
     app.kubernetes.io/part-of: openunison
-  annotations:
-    argocd.argoproj.io/sync-wave: "20"
   name: kube-management-proxy-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{ if eq .Values.network.ingress_type "traefik" }}
   annotations:
+    argocd.argoproj.io/sync-wave: "20"
+  {{ if eq .Values.network.ingress_type "traefik" }}
     {{ if .Values.network.traefik.secure }} 
     traefik.ingress.kubernetes.io/service.serversscheme: https
     {{ end }}

--- a/orchestra/templates/infrastructure/rbac.yaml
+++ b/orchestra/templates/infrastructure/rbac.yaml
@@ -253,6 +253,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: "20"
     audit2rbac.liggitt.net/version: v0.7.0
   labels:
     audit2rbac.liggitt.net/generated: "true"
@@ -261,8 +262,6 @@ metadata:
     app.kubernetes.io/instance: openunison-{{ .Release.Name }}
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: openunison
-  annotations:
-    argocd.argoproj.io/sync-wave: "20"
   name: audit2rbac:system:serviceaccount:openunison:openunison-{{ .Release.Name }}
 rules:
 - apiGroups:
@@ -276,6 +275,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: "20"
     audit2rbac.liggitt.net/version: v0.7.0
   labels:
     audit2rbac.liggitt.net/generated: "true"
@@ -284,8 +284,6 @@ metadata:
     app.kubernetes.io/instance: openunison-{{ .Release.Name }}
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: openunison
-  annotations:
-    argocd.argoproj.io/sync-wave: "20"
   name: audit2rbac:system:serviceaccount:openunison:openunison-{{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/orchestra/templates/infrastructure/service.yaml
+++ b/orchestra/templates/infrastructure/service.yaml
@@ -8,12 +8,11 @@ metadata:
     app.kubernetes.io/instance: openunison-{{ .Release.Name }}
     app.kubernetes.io/component: service
     app.kubernetes.io/part-of: network
-  annotations:
-    argocd.argoproj.io/sync-wave: "20"
   name: openunison-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-  {{ if eq .Values.network.ingress_type "traefik" }}
   annotations:
+    argocd.argoproj.io/sync-wave: "20"
+  {{ if eq .Values.network.ingress_type "traefik" }}  
     {{ if .Values.network.traefik.secure }} 
     traefik.ingress.kubernetes.io/service.serversscheme: https
     {{ end }}

--- a/orchestra/templates/infrastructure/serviceaccount.yaml
+++ b/orchestra/templates/infrastructure/serviceaccount.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  creationTimestamp:
   name: openunison-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/orchestra/values.yaml
+++ b/orchestra/values.yaml
@@ -9,6 +9,7 @@ network:
   ingress_type: nginx
   ingress_certificate: ou-tls-certificate
   ingress_annotations: {}
+  ingressClassName: ""
   istio:
     selectors:
       istio: ingressgateway


### PR DESCRIPTION
HI guys

Currently we can not deploy orchestra anymore, because of duplicated annotations. We use Flux for deployment of Orchestra, which has advanced checks on duplicated keys (not like helm). 

There's also some other fixes in this pr.
We would greatly appreciate it if this release could be released asap.

Thanks