### PR TITLE
Combines annotations

### DIFF
--- a/orchestra/templates/infrastructure/rbac.yaml
+++ b/orchestra/templates/infrastructure/rbac.yaml
@@ -254,8 +254,6 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    audit2rbac.liggitt.net/version: v0.7.0
   labels:
     audit2rbac.liggitt.net/generated: "true"
     audit2rbac.liggitt.net/user: system-serviceaccount-openunison-openunison-{{ .Release.Name }}
@@ -265,6 +263,7 @@ metadata:
     app.kubernetes.io/part-of: openunison
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    audit2rbac.liggitt.net/version: v0.7.0
   name: audit2rbac:system:serviceaccount:openunison:openunison-{{ .Release.Name }}
 rules:
 - apiGroups:
@@ -277,8 +276,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    audit2rbac.liggitt.net/version: v0.7.0
   labels:
     audit2rbac.liggitt.net/generated: "true"
     audit2rbac.liggitt.net/user: system-serviceaccount-openunison-openunison-{{ .Release.Name }}
@@ -288,6 +285,7 @@ metadata:
     app.kubernetes.io/part-of: openunison
   annotations:
     argocd.argoproj.io/sync-wave: "20"
+    audit2rbac.liggitt.net/version: v0.7.0
   name: audit2rbac:system:serviceaccount:openunison:openunison-{{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes instances where the annotations key was declared twice in the same metadata block.  YAML doesn't allow duplicate keys, so any linter or tester will complain about it.  In my case, it is Flux CD's post render checks that catch the issue and block deployment.