### PR TITLE
fix: duplicate securityContext fails with kustomize as helm post-renderer

### DIFF
--- a/orchestra/templates/infrastructure/cronjob.yaml
+++ b/orchestra/templates/infrastructure/cronjob.yaml
@@ -104,7 +104,6 @@ spec:
           dnsPolicy: ClusterFirst
           restartPolicy: Never
           schedulerName: default-scheduler
-          securityContext: {}
           serviceAccount: openunison-operator
           serviceAccountName: openunison-operator
           terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This PR fixes the issue https://github.com/OpenUnison/helm-charts/issues/152

The duplicate securityContext creates problems when using kustomize as a helm post-renderer.