### PR TITLE
Add ingressClassName to orchestra ingress template

### DIFF
--- a/orchestra/templates/infrastructure/ingress-simple.yaml
+++ b/orchestra/templates/infrastructure/ingress-simple.yaml
@@ -16,6 +16,9 @@ metadata:
     app.kubernetes.io/component: ingress-simple
     app.kubernetes.io/part-of: openunison
 spec:
+  {{ if .Values.network.ingress_class_name }}
+  ingressClassName: {{ .Values.network.ingress_class_name }}
+  {{ end }}
   rules:
   - host: {{ .Values.network.openunison_host }}
     http:
@@ -23,7 +26,7 @@ spec:
       - backend:
           service:
             name: openunison-{{ .Release.Name }}
-            port: 
+            port:
               number: 443
         path: "/"
         pathType: Prefix

--- a/orchestra/values.yaml
+++ b/orchestra/values.yaml
@@ -6,6 +6,7 @@ network:
   k8s_url: https://k8s-installer-master.tremolo.lan:6443
   force_redirect_to_tls: true
   createIngressCertificate: true
+  ingress_class_name: ""
   ingress_type: nginx
   ingress_certificate: ou-tls-certificate
   ingress_annotations: {}
@@ -17,7 +18,7 @@ network:
     entrypoints:
       plaintext: web
       tls: websecure
-  
+
 
 cert_template:
   ou: "Kubernetes"
@@ -211,4 +212,4 @@ openunison:
         enabled: false
         admin_group: "CN=openunison-admins,CN=Users,DC=ent2k12,DC=domain,DC=com"
         cluster_admin_group: "CN=k8s_login_ckuster_admins,CN=Users,DC=ent2k12,DC=domain,DC=com"
-      
+


### PR DESCRIPTION
Kubernetes >= 1.18 added `ingressClassName` to the Ingress spec. This change adds it to the orchestra chart ingress template.

There are a couple of whitespace changes included. My editor settings cleaned up some trailing spaces and added a new line.  I can remove if this is a problem.