### PR TITLE
orchestra: allow to set resources for precheck pod

### DIFF
--- a/orchestra/Chart.yaml
+++ b/orchestra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.51
+version: 2.10.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/orchestra/templates/tests/precheck.yaml
+++ b/orchestra/templates/tests/precheck.yaml
@@ -161,6 +161,10 @@ spec:
       image: {{ .Values.openunison.precheck.image | default "ghcr.io/tremolosecurity/python3:1.0.0" }}
       imagePullPolicy: {{ .Values.openunison.imagePullPolicy }}
       command: ["python", "/scripts/check-hosts.py"]
+      {{ if .Values.precheck.resources }}
+      resources:
+        {{- toYaml .Values.precheck.resources | nindent 8 }}
+      {{ end }}
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:

--- a/orchestra/values.yaml
+++ b/orchestra/values.yaml
@@ -17,7 +17,9 @@ network:
     entrypoints:
       plaintext: web
       tls: websecure
-  
+
+precheck:
+  resources: {}
 
 cert_template:
   ou: "Kubernetes"


### PR DESCRIPTION
Now it's impossible to deploy orchestra chart to k8s clusters that force resource limits to exist (e.x. in case of using [gatekeeper](https://github.com/open-policy-agent/gatekeeper)).

This PR allows to set resources for precheck pod.