### PR TITLE
Update precheck.yaml

### DIFF
--- a/orchestra/templates/tests/precheck.yaml
+++ b/orchestra/templates/tests/precheck.yaml
@@ -160,8 +160,10 @@ spec:
     {{- toYaml .Values.services.affinity | nindent 6 }}
   {{ end }}
   restartPolicy: Never
+  {{ if .Values.services.pullSecret }}
   imagePullSecrets:
-  - name: {{ .Values.services.pullSecret }}
+  - name: {{  .Values.services.pullSecret | quote }}
+  {{ end }}
   containers:
     
     - name: test-values


### PR DESCRIPTION
I had this issue on my environment where I had to login into an internal registry, and when deploying this precheck pod, the pod couldnt login in the registry, so I had to overwrite this imagePullSecrets manually into the chart definition