### PR TITLE
Relocate misplaced `readOnlyRootFilesystem` into `securityContext` section

### DIFF
--- a/orchestra/templates/infrastructure/jetstack.yaml
+++ b/orchestra/templates/infrastructure/jetstack.yaml
@@ -83,8 +83,8 @@ spec:
           - "---token-passthrough-audiences={{ .Values.impersonation.passthroughAudience }}"
           {{ end }}
         imagePullPolicy: {{ .Values.openunison.imagePullPolicy }}
-        readOnlyRootFilesystem: true
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:


### PR DESCRIPTION
Fixup for 7a7ce730cbdf1c0ec7a6e3bbcc9b2012cabaa70e