### PR TITLE
fix(orchestra): remove pod-level securityContext from container-level section

### DIFF
--- a/orchestra/templates/infrastructure/mgmt-proxy.yaml
+++ b/orchestra/templates/infrastructure/mgmt-proxy.yaml
@@ -162,6 +162,11 @@ spec:
         {{- toYaml .Values.services.affinity | nindent 8 }}
       {{ end }}
       serviceAccountName: kube-management-proxy-{{ .Release.Name }}
+      {{ if not (.Capabilities.APIVersions.Has "project.openshift.io/v1/Project") }}
+      securityContext:
+        fsGroup: 10001
+        supplementalGroups: [10001]
+      {{ end }}
       containers:
       - image: {{ .Values.impersonation.jetstack_oidc_proxy_image}}
         ports:
@@ -198,8 +203,6 @@ spec:
           {{ if .Capabilities.APIVersions.Has "project.openshift.io/v1/Project" }}
           runAsNonRoot: true
           {{ else }}
-          fsGroup: 10001
-          supplementalGroups: [10001]
           seccompProfile:
             type: RuntimeDefault
           runAsNonRoot: true


### PR DESCRIPTION
mgmt-proxy contains securityContext fields (`fsGroup`, `supplementalGroups`) from pod-level securityContext due to Helm 4 defaulting to SSA. Helm 3 uses CSA which simply prunes fields that are not part of schema before sending request to server for validation.